### PR TITLE
Reap transient block `coproc` processes at safe points.

### DIFF
--- a/share/zshctl/functions/block
+++ b/share/zshctl/functions/block
@@ -81,6 +81,8 @@ integer fd out
     }
     '
 } 2>/dev/null # awk: unknown option -Winteractive ignored
+# Keep the `awk` pid so that `caught` can reap it deterministically.
+o_block[awk]=${!}
 # Keep both the input and output.
 exec {fd}>&p; o_block[try]=$fd
 exec {fd}<&p; o_block[tried]=$fd
@@ -130,6 +132,9 @@ if (( indent )); then
     exec {fd}>&p; o_block[indent]=$fd
     # Close the >&p and <&p of our indent `coproc`.
     coproc :
+    # Reap the no-op `coproc` immediately (see `try` for why transient
+    # children must not exit asynchronously).
+    wait $! 2>/dev/null
     # Set the DIY `try` fd to zero so we know its unallocated.
     o_block[user]=0
 fi

--- a/share/zshctl/functions/block.d/caught
+++ b/share/zshctl/functions/block.d/caught
@@ -28,6 +28,13 @@ _block_close try
 typeset err="$(<&${o_block[tried]})"
 # Close the ouptut side of the try `coproc`.
 _block_close tried
+# The try `coproc` exits once it has echoed the gathered lines. Reap it here
+# at a safe point (see `try` for why transient children must not exit
+# asynchronously).
+if (( o_block[awk] )); then
+    wait $o_block[awk] 2>/dev/null
+    o_block[awk]=0
+fi
 
 # TODO Here down is very indent specific. I notice that I am repending `abend: `
 # to the user message, so maybe that is something I ought to in `abend` and

--- a/share/zshctl/functions/block.d/try
+++ b/share/zshctl/functions/block.d/try
@@ -22,12 +22,30 @@
 
 #
 function try {
-    # TODO Wait on previous set to exit, if it exists.
     # Close the indent file handle so that a long running process like
     # `ssh-agent` do not inherit it and hold it open.
     _block_close indent
     # Close the user `try` handle if one exists.
     _block_close user
+    # Wait on the previous standard error indent `coproc` if it is still
+    # outstanding, which is the case when it was handed to the user by `try
+    # -v` and we've only just now closed the handle above. We must never let
+    # one of our transient `coproc` processes exit asynchronously. The Zsh
+    # SIGCHLD handler allocates memory to record the exit status and glibc
+    # `malloc` is not reentrant, so a child exiting while the parent is in the
+    # middle of allocator work, `regcomp` in a `[[ =~ ]]` was the observed
+    # case, intermittently corrupts the heap and crashes the shell. Reaping
+    # with `wait` parks the exit at a safe point. Same wait as in `caught`.
+    typeset waited
+    if (( o_block[sed] )); then
+        wait $o_block[sed]
+        waited=$?
+        if (( waited && waited != 127 )); then
+            print -u 2 $waited $o_block[pids]
+            exit 1
+        fi
+        o_block[sed]=0
+    fi
     # Create an indentation `coproc` to feed to our try `coproc`.
     coproc {
         coproc :
@@ -48,6 +66,9 @@ function try {
         exec {1}>&p; o_block[user]=$1
         # Close the >&p and <&p of our standard error indent `coproc`.
         coproc :
+        # Reap the no-op `coproc` immediately, before its asynchronous exit
+        # can interrupt allocator work in the parent (see above).
+        wait $! 2>/dev/null
         # Assign the fd to the variable given by the user.
         : ${(P)2::=$1}
     else
@@ -60,6 +81,21 @@ function try {
             o_block[code]=$?
             # Close the >&p and <&p of our standard error indent `coproc`.
             coproc :
+            # The close above is the EOF that retires our standard error
+            # indent `coproc`, and the no-op `coproc` exits immediately. Reap
+            # them both here at a safe point instead of letting SIGCHLD
+            # interrupt allocator work later (see the wait at the top of
+            # `try`).
+            wait $! 2>/dev/null
+            if (( o_block[sed] )); then
+                wait $o_block[sed]
+                waited=$?
+                if (( waited && waited != 127 )); then
+                    print -u 2 $waited $o_block[pids]
+                    exit 1
+                fi
+                o_block[sed]=0
+            fi
         }
         # Retrun the error code.
         return $o_block[code]


### PR DESCRIPTION
`try` retires its standard error indent `sed` and its no-op `coproc`s without reaping them, so their exits deliver SIGCHLD at arbitrary points in the parent shell. Zsh's SIGCHLD handler allocates memory to record background job status, and glibc's single-threaded `malloc` fast path is not reentrant, so an exit that lands in the middle of allocator work corrupts the heap. In the `acreops` Tekton pipelines this intermittently killed `manifests` and `apply` steps, always inside the `[[ =~ ]]` message match right after a `try` (`regcomp` is the widest stretch of allocator work under a `try`), with `malloc(): unsorted double linked list corrupted` and friends, or a silent SIGSEGV, at roughly 1 in 100 pull request flows (5 confirmed in the last 14 days across 485 invocations, one of them a silent SIGSEGV found via TaskRun exit codes rather than logs). The exposure exists through current zsh master (`Src/Modules/regex.c` never queues signals and the handler's `addbgstatus` allocates), so upgrading zsh does not fix it.

This implements the `TODO Wait on previous set to exit, if it exists.` in `try`: every transient `coproc` is reaped with `wait` at the point it is retired. The `sed` and the no-op `coproc` in `try`'s `always` block, a user-handle `sed` at the top of the following `try`, the no-op `coproc` in `block`, and the `awk` gatherer in `caught`. This is the same wait `caught` already performs for the last `sed`.

Verified in the `acreops/tekton:zshctl` image (zsh 5.8.1, glibc 2.35, Ubuntu 22.04): a loop of `try :` followed by three `[[ =~ ]]` matches crashes 4 of 4 workers unpatched (three SIGSEGV, one `corrupted size vs. prev_size` abort) and survives 4 x 15,000 iterations patched. Success, failure (`tried`/`caught`), and `try -v` outputs are byte-identical before and after. A background child that inherits and holds the pipe delays teardown by its lifetime both before and after this change, since the `caught` wait for the indent `coproc` already imposed that bound.
