### PR TITLE
Add `extend override`: session-local `<PROGRAM>_OVERRIDE` to redirect at a working copy

### DIFF
--- a/bin/zshctl
+++ b/bin/zshctl
@@ -256,6 +256,19 @@ function {
                 command_path+=( ~/.local/share/${zshctl[program]}/extensions/*(N) )
             fi
         fi
+        # A session-local override. `<PROGRAM>_OVERRIDE` (e.g. `ACRECTL_OVERRIDE`)
+        # is a colon-separated list of extension directories appended last, so
+        # their commands and functions win over the installed extensions (the
+        # loop below is last-writer-wins). This lets a single shell session
+        # redirect the program at a working copy — a git worktree, say — without
+        # touching the per-user `~/.local/share` symlinks that every session and
+        # every other program share. Set and cleared with `<program> extend override`.
+        typeset override_variable=${(U)zshctl[program]}
+        override_variable=${override_variable//[^A-Za-z0-9]/_}_OVERRIDE
+        typeset override=${(P)override_variable:-}
+        if [[ -n $override ]]; then
+            command_path+=( ${(s.:.)override}(N/) )
+        fi
     fi
     # Preserve the system fpath for a systemload function.
     zshctl[fpath]=$fpath

--- a/share/zshctl/commands/extend/override/command.zsh
+++ b/share/zshctl/commands/extend/override/command.zsh
@@ -61,6 +61,7 @@ function :execute:extend:override {
     typeset dir=${found[1]:A:h}
     print -r -- "export $variable=${(q)dir}"
     print -u 2 -P "%F{8}→ ${zshctl[program]} now overrides \`${extend[link_as]}\` from ${dir} (this session)%f"
+    print -u 2 -P "%F{8}  apply to this shell:  eval \"\$(${zshctl[program]} extend override)\"%f"
 }
 
 function :complete:extend:override {

--- a/share/zshctl/commands/extend/override/command.zsh
+++ b/share/zshctl/commands/extend/override/command.zsh
@@ -38,6 +38,7 @@ function :execute:extend:override {
     if (( ${o_clear:-0} )); then
         print -r -- "unset $variable"
         print -u 2 -P "%F{8}→ ${zshctl[program]} override cleared for this session%f"
+        print -u 2 -P "%F{8}  apply to this shell:  eval \"\$(${zshctl[program]} extend override --clear)\"%f"
         return
     fi
     if (( ${o_show:-0} )); then

--- a/share/zshctl/commands/extend/override/command.zsh
+++ b/share/zshctl/commands/extend/override/command.zsh
@@ -1,0 +1,69 @@
+function :help:extend:override {
+    heredoc -v help -q <<'    EOF'
+        # desc
+        Redirect \`${zshctl[program]}\` at a working-copy extension for this shell session.
+        # arg -- [ directory ]
+        # opt help
+        Display help for \`${zshctl[program]} extend override\`.
+        # opt clear
+        Emit an \`unset\` for the override variable instead of an \`export\`.
+        # opt show
+        Print the current override value, if any, and exit.
+        # man
+        ## DESCRIPTION
+        Finds the \`${zshctl[program]}\` extension under the current git worktree (or under
+        DIRECTORY) and prints an \`export <PROGRAM>\_OVERRIDE=<dir>\` line. Eval it to point
+        THIS shell session's \`${zshctl[program]}\` at that working copy: its commands and
+        functions win over the installed extension, while the shared \`~/.local/share\`
+        symlinks — and every other shell session — are left untouched. Clear with \`--clear\`.
+
+        \`<PROGRAM>\_OVERRIDE\` is a colon-separated list of extension directories, so it
+        composes if you eval more than one.
+        ## USAGE
+            eval "\$(${zshctl[program]} extend override)"
+            eval "\$(${zshctl[program]} extend override --clear)"
+        ## OPTIONS
+        > options
+    EOF
+}
+
+function :args:extend:override {
+    eval "$(args -bx h,help ,clear ,show -- "$@")"
+}
+
+function :execute:extend:override {
+    typeset variable=${(U)zshctl[program]}
+    variable=${variable//[^A-Za-z0-9]/_}_OVERRIDE
+
+    if (( ${o_clear:-0} )); then
+        print -r -- "unset $variable"
+        print -u 2 -P "%F{8}→ ${zshctl[program]} override cleared for this session%f"
+        return
+    fi
+    if (( ${o_show:-0} )); then
+        print -r -- ${(P)variable:-}
+        return
+    fi
+
+    # Detect the extension the way `extend link` does — the directory holding the
+    # program's extension marker — but search from the git worktree root so it
+    # works from anywhere inside the checkout, not just its top.
+    typeset root=${1:-$(git rev-parse --show-toplevel 2>/dev/null)}
+    : ${root:=.}
+    typeset found=( $root/**/$zshctl[program].extension.zsh(N) )
+    case ${#found} in
+    (0) abend 'fatal: no %s.extension.zsh found under %s' $zshctl[program] ${(qqq)root} ;;
+    (1) ;;
+    (*) abend 'fatal: multiple extension configurations found under %s' ${(qqq)root} ;;
+    esac
+    typeset -A extend
+    source $found[1]
+    typeset dir=${found[1]:A:h}
+    print -r -- "export $variable=${(q)dir}"
+    print -u 2 -P "%F{8}→ ${zshctl[program]} now overrides \`${extend[link_as]}\` from ${dir} (this session)%f"
+}
+
+function :complete:extend:override {
+    [[ $zshctl[args:incomplete] = -* ]] && return
+    [[ $zshctl[args:state] = arguments ]] && completion directories
+}

--- a/share/zshctl/functions/args
+++ b/share/zshctl/functions/args
@@ -382,6 +382,12 @@ case $zshctl[args:mode] in
     # amendment to the state that makes sense for completion.
     if [[ $state = arguments && $zshctl[args:incomplete] = -* ]]; then
         zshctl[args:state]=option
+    elif [[ $state = option && $zshctl[args:incomplete] != -* ]]; then
+        # Interspersed positionals leave the loop in `option` state, and the
+        # descent skips the `:complete` function for that state — so only the
+        # first argument would ever complete. The cursor is on a word that is
+        # not an option, so complete arguments.
+        zshctl[args:state]=arguments
     else
         zshctl[args:state]=$state
     fi


### PR DESCRIPTION
### Description
- `<PROGRAM>_OVERRIDE` (e.g. `ACRECTL_OVERRIDE`): a colon-separated list of extension directories, honored by command discovery in `bin/zshctl` and appended **last** to `command_path` so its commands and functions win over the installed `~/.local/share` extensions. Session-local (an env var), so concurrent shells and other zshctl programs are unaffected.
- `zshctl extend override [--clear] [--show] [directory]`: finds the extension under the current git worktree (or `directory`, via the same `<program>.extension.zsh` detection as `extend link`) and prints an `export`/`unset` line to `eval`; confirmation to stderr.
- Second commit, a separate completion fix: arguments beyond the first never completed. With interspersed arguments (`-@`), consumed positionals leave the parser in `option` state and `_zshctl_descend_completion` skips the node's `:complete` function for that state. The completion-mode state amendment in `args` now maps `option` with a non-dash incomplete to `arguments`, so a command taking several arguments (e.g. `acrectl kube helm kratos al<TAB>`) completes at every position. Dash incompletes still route to option completion.

### Motivation
Lets concurrent sessions each redirect a program at their own git worktree for testing, without checking out branches in a shared worktree or repointing shared per-user extension symlinks.

### Risk
Opt-in and additive: with the var unset, discovery is unchanged. Verified a command appears only when the var points at a dir providing it; existing commands and other extensions still resolve; `--clear`/`--show`/`--help`/auto-detect all work.

For the completion fix, verified through the `__complete` entry point: second and third positions complete, `-` incompletes still offer options, option-value slots are unaffected, and completers guarded with `(( $# )) && return` (the single-argument idiom) behave as before. Completers without that guard are now called at later positions too — at worst they re-offer first-argument suggestions where they previously offered nothing.